### PR TITLE
Attribute id 2 bytes

### DIFF
--- a/include/odva_ethernetip/path.h
+++ b/include/odva_ethernetip/path.h
@@ -69,6 +69,8 @@ public:
    */
   Path(EIP_USINT class_id, EIP_USINT instance_id, EIP_USINT attribute_id,
     bool pad_after_length = false);
+  Path(EIP_USINT class_id, EIP_USINT instance_id, EIP_UINT attribute_id,
+    bool pad_after_length = false);
 
   /**
    * Shortcut to construct a path to the given logical class instance
@@ -107,6 +109,7 @@ public:
    * @param attribute_id ID Number of attribute to add to path
    */
   void addLogicalAttribute(EIP_USINT attribute_id);
+  void addLogicalAttribute(EIP_UINT attribute_id);
 
   /**
    * Add a logical connection point segment
@@ -166,6 +169,11 @@ public:
     throw std::logic_error("Not implemented");
   }
 
+  /**
+   * Prints path bytes at std output
+   */
+  void print() const;
+
 private:
   bool pad_after_length_;
   vector<EIP_USINT> path_buf_;
@@ -176,6 +184,7 @@ private:
    * @param data Data to add to path
    */
   void addSegment(EIP_USINT type, EIP_USINT data);
+  void addSegment(EIP_USINT type, EIP_UINT data);
 };
 
 } // namespace eip

--- a/include/odva_ethernetip/path.h
+++ b/include/odva_ethernetip/path.h
@@ -27,6 +27,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #define ODVA_ETHERNETIP_PATH_H
 
 #include <vector>
+#include <iostream>
+#include <iomanip>
 
 #include "odva_ethernetip/eip_types.h"
 #include "odva_ethernetip/serialization/reader.h"
@@ -170,9 +172,21 @@ public:
   }
 
   /**
-   * Prints path bytes at std output
+   * Prints path bytes to a given output stream
    */
-  void print() const;
+  friend std::ostream& operator<<(std::ostream& os, const Path& p)
+  {
+	os << "PATH: ";
+	os.setf(std::ios_base::hex , std::ios_base::basefield);
+	for (unsigned int ii=0; ii< p.path_buf_.size(); ii++)
+	{
+		os << std::setw(2) << std::setfill('0') << (unsigned short int)p.path_buf_.at(ii);
+		if ( (ii+1)%2 == 0 )  os << " ";
+	}
+	os << std::endl;
+	os.setf(std::ios_base::dec , std::ios_base::basefield);
+	return os;
+  }
 
 private:
   bool pad_after_length_;

--- a/include/odva_ethernetip/session.h
+++ b/include/odva_ethernetip/session.h
@@ -139,6 +139,8 @@ public:
    */
   void setSingleAttributeSerializable(EIP_USINT class_id, EIP_USINT instance_id,
     EIP_USINT attribute_id, shared_ptr<Serializable> data);
+  void setSingleAttributeSerializable(EIP_USINT class_id, EIP_USINT instance_id,
+    EIP_UINT attribute_id, shared_ptr<Serializable> data);
 
   /**
    * Shortcut to set a single attribute from a primitive type
@@ -150,6 +152,14 @@ public:
   template <typename T>
   void setSingleAttribute(EIP_USINT class_id, EIP_USINT instance_id,
     EIP_USINT attribute_id, T v)
+  {
+    shared_ptr< SerializablePrimitive<T> > data =
+      make_shared< SerializablePrimitive<T> > (v);
+    setSingleAttributeSerializable(class_id, instance_id, attribute_id, data);
+  }
+  template <typename T>
+  void setSingleAttribute(EIP_USINT class_id, EIP_USINT instance_id,
+    EIP_UINT attribute_id, T v)
   {
     shared_ptr< SerializablePrimitive<T> > data =
       make_shared< SerializablePrimitive<T> > (v);

--- a/include/odva_ethernetip/session.h
+++ b/include/odva_ethernetip/session.h
@@ -105,6 +105,8 @@ public:
    */
   void getSingleAttributeSerializable(EIP_USINT class_id, EIP_USINT instance_id,
     EIP_USINT attribute_id, Serializable& result);
+  void getSingleAttributeSerializable(EIP_USINT class_id, EIP_USINT instance_id,
+    EIP_UINT attribute_id, Serializable& result);
 
   /**
    * Shortcut to get a single attribute as a primitive type
@@ -115,6 +117,13 @@ public:
    */
   template <typename T>
   T getSingleAttribute(EIP_USINT class_id, EIP_USINT instance_id, EIP_USINT attribute_id, T v)
+  {
+    SerializablePrimitive<T> data;
+    getSingleAttributeSerializable(class_id, instance_id, attribute_id, data);
+    return data.data;
+  }
+  template <typename T>
+  T getSingleAttribute(EIP_USINT class_id, EIP_USINT instance_id, EIP_UINT attribute_id, T v)
   {
     SerializablePrimitive<T> data;
     getSingleAttributeSerializable(class_id, instance_id, attribute_id, data);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -27,10 +27,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
 #include <boost/asio.hpp>
 
-#include <iostream>
-#include <unistd.h>
-#include <iomanip>
-
 namespace eip {
 
 Path::Path(bool pad_after_length) : pad_after_length_(pad_after_length)
@@ -45,7 +41,6 @@ Path::Path(EIP_USINT class_id, EIP_USINT instance_id, EIP_USINT attribute_id,
   addLogicalClass(class_id);
   addLogicalInstance(instance_id);
   addLogicalAttribute(attribute_id);
-  //this->print();
 }
 
 Path::Path(EIP_USINT class_id, EIP_USINT instance_id, EIP_UINT attribute_id,
@@ -55,7 +50,6 @@ Path::Path(EIP_USINT class_id, EIP_USINT instance_id, EIP_UINT attribute_id,
   addLogicalClass(class_id);
   addLogicalInstance(instance_id);
   addLogicalAttribute(attribute_id);
-  //this->print();
 }
 
 
@@ -64,7 +58,6 @@ Path::Path(EIP_USINT class_id, EIP_USINT instance_id) : pad_after_length_(false)
   path_buf_.reserve(4);
   addLogicalClass(class_id);
   addLogicalInstance(instance_id);
-  //this->print();
 }
 
 void Path::addSegment(EIP_USINT type, EIP_USINT data)
@@ -121,17 +114,6 @@ Writer& Path::serialize(Writer& writer, bool pad_after_length) const
   }
   writer.writeBuffer(boost::asio::buffer(path_buf_));
   return writer;
-}
-
-void Path::print() const
-{
-  std::cout << "PATH: ";
-  for (unsigned int ii=0; ii< path_buf_.size(); ii++)
-  {
-    std::cout << std::hex << std::setfill('0') << std::setw(2) << (unsigned short int)path_buf_.at(ii);
-	if ( (ii+1)%2 == 0 )  std::cout << " ";
-  }
-  std::cout << std::dec << std::endl;
 }
 
 } // namespace eip

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -27,6 +27,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
 #include <boost/asio.hpp>
 
+#include <iostream>
+#include <unistd.h>
+#include <iomanip>
+
 namespace eip {
 
 Path::Path(bool pad_after_length) : pad_after_length_(pad_after_length)
@@ -41,19 +45,39 @@ Path::Path(EIP_USINT class_id, EIP_USINT instance_id, EIP_USINT attribute_id,
   addLogicalClass(class_id);
   addLogicalInstance(instance_id);
   addLogicalAttribute(attribute_id);
+  //this->print();
 }
+
+Path::Path(EIP_USINT class_id, EIP_USINT instance_id, EIP_UINT attribute_id,
+  bool pad_after_length) : pad_after_length_(pad_after_length)
+{
+  path_buf_.reserve(7);
+  addLogicalClass(class_id);
+  addLogicalInstance(instance_id);
+  addLogicalAttribute(attribute_id);
+  //this->print();
+}
+
 
 Path::Path(EIP_USINT class_id, EIP_USINT instance_id) : pad_after_length_(false)
 {
   path_buf_.reserve(4);
   addLogicalClass(class_id);
   addLogicalInstance(instance_id);
+  //this->print();
 }
 
 void Path::addSegment(EIP_USINT type, EIP_USINT data)
 {
   path_buf_.push_back(type);
   path_buf_.push_back(data);
+}
+
+void Path::addSegment(EIP_USINT type, EIP_UINT data)
+{
+  path_buf_.push_back(type);
+  path_buf_.push_back( (EIP_USINT)(data&0xff) );
+  path_buf_.push_back( (EIP_USINT)((data&0xff00)>>8) );
 }
 
 void Path::addLogicalClass(EIP_USINT class_id)
@@ -69,6 +93,11 @@ void Path::addLogicalInstance(EIP_USINT instance_id)
 void Path::addLogicalAttribute(EIP_USINT attribute_id)
 {
   addSegment(0x30, attribute_id);
+}
+
+void Path::addLogicalAttribute(EIP_UINT attribute_id)
+{
+  addSegment(0x31, attribute_id);
 }
 
 void Path::addLogicalConnectionPoint(EIP_USINT connection_id)
@@ -92,6 +121,17 @@ Writer& Path::serialize(Writer& writer, bool pad_after_length) const
   }
   writer.writeBuffer(boost::asio::buffer(path_buf_));
   return writer;
+}
+
+void Path::print() const
+{
+  std::cout << "PATH: ";
+  for (unsigned int ii=0; ii< path_buf_.size(); ii++)
+  {
+    std::cout << std::hex << std::setfill('0') << std::setw(2) << (unsigned short int)path_buf_.at(ii);
+	if ( (ii+1)%2 == 0 )  std::cout << " ";
+  }
+  std::cout << std::dec << std::endl;
 }
 
 } // namespace eip

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -236,6 +236,17 @@ void Session::getSingleAttributeSerializable(EIP_USINT class_id, EIP_USINT insta
   resp_data.getResponseDataAs(result);
 }
 
+void Session::getSingleAttributeSerializable(EIP_USINT class_id, EIP_USINT instance_id,
+  EIP_UINT attribute_id, Serializable& result)
+{
+  shared_ptr<Serializable> no_data;
+  RRDataResponse resp_data = sendRRDataCommand(0x0E,
+    Path(class_id, instance_id, attribute_id), no_data);
+
+  resp_data.getResponseDataAs(result);
+}
+
+
 void Session::setSingleAttributeSerializable(EIP_USINT class_id,
   EIP_USINT instance_id, EIP_USINT attribute_id, shared_ptr<Serializable> data)
 {

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -60,8 +60,7 @@ Session::Session(shared_ptr<Socket> socket, shared_ptr<Socket> io_socket,
   boost::random::uniform_int_distribution<> dist(0, 0xFFFF);
   next_connection_id_ = gen();
   next_connection_sn_ = dist(gen);
-  cout << "Generated starting connection ID " << next_connection_id_
-    << " and SN " << next_connection_sn_ << endl;;
+  //cout << "Generated starting connection ID " << next_connection_id_ << " and SN " << next_connection_sn_ << endl;;
 }
 
 Session::~Session()
@@ -81,12 +80,12 @@ Session::~Session()
 
 void Session::open(string hostname, string port, string io_port)
 {
-  cout << "Resolving hostname and connecting socket" << endl;
+  //cout << "Resolving hostname and connecting socket" << endl;
   socket_->open(hostname, port);
   io_socket_->open(hostname, io_port);
 
   // create the registration message
-  cout << "Creating and sending the registration message" << endl;
+  //cout << "Creating and sending the registration message" << endl;
   shared_ptr<RegisterSessionData> reg_data = make_shared<RegisterSessionData>();
   EncapPacket reg_msg(EIP_CMD_REGISTER_SESSION, 0, reg_data);
 
@@ -149,7 +148,7 @@ void Session::open(string hostname, string port, string io_port)
   }
 
   session_id_ = response.getHeader().session_handle;
-  cout << "Successfully opened session ID " << session_id_ << endl;
+  //cout << "Successfully opened session ID " << session_id_ << endl;
 }
 
 void Session::close()
@@ -170,12 +169,12 @@ void Session::close()
 
 EncapPacket Session::sendCommand(EncapPacket& req)
 {
-  cout << "Sending Command" << endl;
+  //cout << "Sending Command" << endl;
   socket_->send(req);
 
-  cout << "Waiting for response" << endl;
+  //cout << "Waiting for response" << endl;
   size_t n = socket_->receive(buffer(recv_buffer_));
-  cout << "Received response of " << n << " bytes" << endl;
+  //cout << "Received response of " << n << " bytes" << endl;
 
   BufferReader reader(buffer(recv_buffer_, n));
   EncapPacket result;
@@ -247,7 +246,7 @@ void Session::setSingleAttributeSerializable(EIP_USINT class_id,
 RRDataResponse Session::sendRRDataCommand(EIP_USINT service, const Path& path,
   shared_ptr<Serializable> data)
 {
-  cout << "Creating RR Data Request" << endl;
+  //cout << "Creating RR Data Request" << endl;
   shared_ptr<RRDataRequest> req_data =
     make_shared<RRDataRequest> (service, path, data);
   EncapPacket encap_pkt(EIP_CMD_SEND_RR_DATA, session_id_, req_data);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -253,6 +253,12 @@ void Session::setSingleAttributeSerializable(EIP_USINT class_id,
   RRDataResponse resp_data = sendRRDataCommand(0x10,
     Path(class_id, instance_id, attribute_id), data);
 }
+void Session::setSingleAttributeSerializable(EIP_USINT class_id,
+  EIP_USINT instance_id, EIP_UINT attribute_id, shared_ptr<Serializable> data)
+{
+  RRDataResponse resp_data = sendRRDataCommand(0x10,
+    Path(class_id, instance_id, attribute_id), data);
+}
 
 RRDataResponse Session::sendRRDataCommand(EIP_USINT service, const Path& path,
   shared_ptr<Serializable> data)


### PR DESCRIPTION
This PR allows to operate with devices with 2-Byte long Attribute ID's, instead of just 1-Byte long attribute ID.
Further details at commit comments.
Thanks for reviewing it.  