### PR TITLE
feat(udp_socket): Optional local_ip

### DIFF
--- a/include/odva_ethernetip/socket/udp_socket.h
+++ b/include/odva_ethernetip/socket/udp_socket.h
@@ -46,8 +46,8 @@ class UDPSocket : public Socket
 {
 public:
 
-  UDPSocket(io_service& io_serv, unsigned short local_port)
-    : socket_(io_serv), local_endpoint_(udp::v4(), local_port) { }
+  UDPSocket(io_service& io_serv, unsigned short local_port, std::string local_ip="0.0.0.0")
+    : socket_(io_serv), local_endpoint_(boost::asio::ip::address::from_string(local_ip), local_port) { }
 
   /**
    * Open the socket to connect to the given hostname and port


### PR DESCRIPTION
Optional local ip specification that is used for binding. Default is still `0.0.0.0` so we will not break the API. 

Motivation for this pull request is the use of this library in the `omron_os32_driver` package. The `0.0.0.0` binding prevents using multiple scanners on different interfaces, as described in https://github.com/ros-drivers/omron/issues/12 