### PR TITLE
Add support for early versions of CIP specification

### DIFF
--- a/include/odva_ethernetip/connection.h
+++ b/include/odva_ethernetip/connection.h
@@ -92,7 +92,17 @@ public:
   /**
    * Create the forward open request from the data in this connection object
    */
-  shared_ptr<ForwardOpenRequest> createForwardOpenRequest();
+  shared_ptr<ForwardOpenRequest> createForwardOpenRequest()
+  {
+    // Maintains backwards compatability
+    return createForwardOpenRequest(false);
+  }
+
+  /**
+   * Create the forward open request from the data in this connection object
+   * @param use_legacy_forward_open_request use 16 bit connection parameters instead of news 32 bit parameters
+   */
+  shared_ptr<ForwardOpenRequest> createForwardOpenRequest(bool use_legacy_forward_open_request);
 
   /**
    * Create a forward close request from the data in this connection object

--- a/include/odva_ethernetip/session.h
+++ b/include/odva_ethernetip/session.h
@@ -88,6 +88,11 @@ public:
   void close();
 
   /**
+   * Close the session without unregistering the session and just closing the port
+   */
+  void closeWithoutUnregister();
+
+  /**
    * Get the ID number assigned to this session by the target
    * @return session ID number
    */
@@ -153,7 +158,23 @@ public:
    * @param t_to_o Target to origin connection info
    */
   int createConnection(const EIP_CONNECTION_INFO_T& o_to_t,
-    const EIP_CONNECTION_INFO_T& t_to_o);
+    const EIP_CONNECTION_INFO_T& t_to_o)
+  {
+    // Maintains backwards compatability
+    return createConnection(o_to_t, t_to_o, 0x5B, false);
+  }
+
+  /**
+   * Create an Ethernet/IP Connection for sending implicit messages
+   * @param o_to_t Origin to target connection info
+   * @param t_to_o Target to origin connection info
+   * @param service Service code to send
+   * @param use_legacy_forward_open_request use 16 bit connection parameters instead of news 32 bit parameters
+   */
+  int createConnection(const EIP_CONNECTION_INFO_T& o_to_t,
+    const EIP_CONNECTION_INFO_T& t_to_o,
+    EIP_USINT service,
+    bool use_legacy_forward_open_request);
 
   /**
    * Close the given connection number

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -56,9 +56,9 @@ void Connection::setConnectionPoints(EIP_USINT origin, EIP_USINT target)
   path_.addLogicalConnectionPoint(target);
 }
 
-shared_ptr<ForwardOpenRequest> Connection::createForwardOpenRequest()
+shared_ptr<ForwardOpenRequest> Connection::createForwardOpenRequest(bool use_legacy_forward_open_request)
 {
-  shared_ptr<ForwardOpenRequest> req = make_shared<ForwardOpenRequest> ();
+  shared_ptr<ForwardOpenRequest> req = make_shared<ForwardOpenRequest> (use_legacy_forward_open_request);
 
   req->originator_vendor_id = originator_vendor_id;
   req->originator_sn = originator_sn;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -158,6 +158,11 @@ void Session::close()
 
   CONSOLE_BRIDGE_logInform("Session closed");
 
+  closeWithoutUnregister();
+}
+
+void Session::closeWithoutUnregister()
+{
   socket_->close();
   io_socket_->close();
   session_id_ = 0;
@@ -294,7 +299,9 @@ RRDataResponse Session::sendRRDataCommand(EIP_USINT service, const Path& path,
 }
 
 int Session::createConnection(const EIP_CONNECTION_INFO_T& o_to_t,
-  const EIP_CONNECTION_INFO_T& t_to_o)
+  const EIP_CONNECTION_INFO_T& t_to_o,
+  EIP_USINT service,
+  bool use_legacy_forward_open_request)
 {
   Connection conn(o_to_t, t_to_o);
   conn.originator_vendor_id = my_vendor_id_;
@@ -303,8 +310,8 @@ int Session::createConnection(const EIP_CONNECTION_INFO_T& o_to_t,
   conn.o_to_t_connection_id = next_connection_id_++;
   conn.t_to_o_connection_id = next_connection_id_++;
 
-  shared_ptr<ForwardOpenRequest> req = conn.createForwardOpenRequest();
-  RRDataResponse resp_data = sendRRDataCommand(0x5B, Path(0x06, 1), req);
+  shared_ptr<ForwardOpenRequest> req = conn.createForwardOpenRequest(use_legacy_forward_open_request);
+  RRDataResponse resp_data = sendRRDataCommand(service, Path(0x06, 1), req);
   ForwardOpenSuccess result;
   resp_data.getResponseDataAs(result);
   if (!conn.verifyForwardOpenResult(result))


### PR DESCRIPTION
http://read.pudn.com/downloads589/doc/2410232/CIP%20Vol1_3.3.pdf
Page 95
Section 3-5.5.1.1
connection parameters are only 16 bits

Also adds an option to not fully close the conncetion. This allows reconnection for slightly offspec devices.